### PR TITLE
Develop

### DIFF
--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,133 @@
+-- V1__init.sql
+-- Initial database schema setup
+
+-- ENUM 타입 정의
+-- ENUM types are defined first as they are used in the table definitions.
+CREATE TYPE user_role_enum AS ENUM (
+    'USER',     -- 일반 시민 사용자
+    'OFFICIAL', -- 인증된 공무원 사용자
+    'ADMIN'     -- 시스템 관리자
+);
+CREATE TYPE region_enum AS ENUM (
+    'SUWON', 'SEONGNAM', 'UIJEONGBU', 'ANYANG', 'BUCHEON', 'GWANGMYEONG',
+    'PYEONGTAEK', 'DONGDUCHEON', 'ANSAN', 'GOYANG', 'GWACHEON', 'GURI',
+    'NAMYANGJU', 'OSAN', 'SIHEUNG', 'GUNPO', 'UIWANG', 'HANAM', 'YONGIN',
+    'PAJU', 'ICHEON', 'ANSEONG', 'GIMPO', 'HWASEONG', 'GWANGJU', 'YANGJU',
+    'POCHEON', 'YEOJU'
+);
+CREATE TYPE access_level_enum AS ENUM (
+    'PUBLIC',            -- 누구나 참여 가능
+    'OFFICIALS_ONLY',  -- 공무원만 참여 가능
+    'USER_ONLY'
+);
+CREATE TYPE message_type_enum AS ENUM (
+    'TEXT',     -- 일반 텍스트 메시지
+    'IMAGE',    -- 이미지 메시지
+    'ENTRY',    -- 입장 알림 메시지 (시스템)
+    'EXIT'      -- 퇴장 알림 메시지 (시스템)
+);
+CREATE TYPE proposal_status_enum AS ENUM (
+    'DRAFTING',         -- 내용 작성 중
+    'SAVING'            -- 저장 상태
+    'PENDING_CONSENT',  -- 동의 진행 중
+    'CONSENT_FAILED',   -- 합의 실패
+    'READY_TO_SUBMIT',  -- 제출 가능
+    'SUBMITTED'         -- 외부 시스템에 제출 완료
+);
+
+
+-- 사용자 테이블 (users)
+-- Stores user account information.
+CREATE TABLE users
+(
+    user_id        BIGSERIAL PRIMARY KEY,
+    login_id       VARCHAR(30) UNIQUE NOT NULL,
+    login_pw       VARCHAR(255)       NOT NULL,
+    name           VARCHAR(50)        NOT NULL,
+    nickname       VARCHAR(50) UNIQUE NOT NULL,
+    email          VARCHAR(50) UNIQUE NOT NULL,
+    phone_number   VARCHAR(20) UNIQUE NOT NULL,
+    role           user_role_enum     NOT NULL DEFAULT 'USER',
+    created_at     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMP WITH TIME ZONE,
+    deleted_at     TIMESTAMP WITH TIME ZONE
+);
+COMMENT ON TABLE users IS '사용자 정보를 저장하는 테이블';
+COMMENT ON COLUMN users.login_pw IS '비밀번호는 해시 처리하여 저장';
+
+
+-- 논의방 테이블 (discussion_rooms)
+-- Represents a chat room or a space for discussion.
+CREATE TABLE discussion_rooms
+(
+    room_id         BIGSERIAL PRIMARY KEY,
+    title           VARCHAR(100)      NOT NULL,
+    description     VARCHAR(255),
+    region          region_enum NOT NULL,
+    access_level    access_level_enum NOT NULL DEFAULT 'PUBLIC',
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP WITH TIME ZONE,
+    deleted_at      TIMESTAMP WITH TIME ZONE
+);
+COMMENT ON TABLE discussion_rooms IS '논의가 이루어지는 공간(채팅방) 테이블';
+
+
+-- 멤버 테이블 (members)
+-- Junction table linking users and discussion_rooms (Many-to-Many).
+CREATE TABLE members
+(
+    member_id       BIGSERIAL PRIMARY KEY,
+    user_id         BIGINT NOT NULL,
+    room_id         BIGINT NOT NULL,
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_members_user FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE,
+    CONSTRAINT fk_members_discussion_room FOREIGN KEY (room_id) REFERENCES discussion_rooms (room_id) ON DELETE CASCADE,
+    UNIQUE (user_id, room_id) -- 한 사용자는 한 논의방에 한 번만 참여 가능
+);
+COMMENT ON TABLE members IS '사용자와 논의방의 다대다 관계를 위한 조인 테이블';
+
+
+-- 채팅 테이블 (chats)
+-- Stores all messages sent within discussion rooms.
+CREATE TABLE chat
+(
+    chat_id         BIGSERIAL PRIMARY KEY,
+    room_id         BIGINT            NOT NULL,
+    sender_id       BIGINT            NOT NULL,
+    content         TEXT              NOT NULL,
+    chat_type       message_type_enum    NOT NULL DEFAULT 'TEXT',
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_chat_discussion_room FOREIGN KEY (room_id) REFERENCES discussion_rooms (room_id) ON DELETE CASCADE,
+    CONSTRAINT fk_chat_sender FOREIGN KEY (sender_id) REFERENCES users (user_id) ON DELETE SET NULL -- 발신자 탈퇴 시 메시지는 남도록 SET NULL 처리
+);
+COMMENT ON TABLE chat IS '논의방에서 주고받은 메시지 정보를 저장하는 테이블';
+COMMENT ON COLUMN chat.sender_id IS '메시지를 보낸 사용자 ID';
+
+
+-- 솔루션 제안서 테이블 (proposals)
+-- Stores proposals submitted within a discussion room.
+CREATE TABLE proposals
+(
+    proposal_id       BIGSERIAL PRIMARY KEY,
+    room_id           BIGINT            NOT NULL,
+    author_id         BIGINT,                      -- 마지막 저장자 ID (NULL 허용)
+    title             VARCHAR(100)      NOT NULL,
+    contents          JSONB             NOT NULL,
+    required_consents INTEGER           NOT NULL DEFAULT 1,
+    consent_deadline  TIMESTAMP WITH TIME ZONE,
+    status            proposal_status_enum NOT NULL DEFAULT 'DRAFTING',
+    consents          JSONB,
+    version           BIGINT            NOT NULL DEFAULT 1,
+    created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        TIMESTAMP WITH TIME ZONE,
+    deleted_at        TIMESTAMP WITH TIME ZONE,
+
+    -- 외래 키 제약조건
+    CONSTRAINT fk_proposals_discussion_room FOREIGN KEY (room_id) REFERENCES discussion_rooms (room_id) ON DELETE CASCADE,
+    CONSTRAINT fk_proposals_author FOREIGN KEY (author_id) REFERENCES users (user_id) ON DELETE SET NULL
+);
+COMMENT ON TABLE proposals IS '논의방 내에서 제출된 제안서를 관리하는 테이블';
+COMMENT ON COLUMN proposals.author_id IS '제안서를 작성한 사용자 ID';
+COMMENT ON COLUMN proposals.consents IS '동의한 사용자 목록 등을 JSON 형태로 저장';


### PR DESCRIPTION
## PR 요약
> 이 PR은 프로젝트의 초기 데이터베이스 스키마를 설정하고, Flyway를 이용한 형상 관리 기반을 마련하는 것을 목적으로 한다
애플리케이션 실행 시 V1__init.sql 스크립트를 통해 핵심 도메인(사용자, 논의방, 제안서 등)의 테이블이 자동으로 생성되도록 구성하였음

## 변경 내용
- Flyway를 이용한 데이터베이스 스키마 버전 관리 기능 도입
- 사용자(users), 논의방(discussion_rooms), 멤버(members), 채팅(chat), 제안서(proposals) 테이블 스키마 정의 (V1__init.sql)

### **버그 수정:** 
(수정된 버그에 대한 설명 없으면 비고)

### **성능 개선:** 
(개선된 부분 및 관련 데이터 없으면 비고)

### **기타:** 
(기타 변경 내용 없으면 비고)

## 마주했던 문제 상황
> 초기 설정에서 spring.flyway.enabled=false로 되어 있어 Flyway가 동작하지 않는 문제가 있었습니다. 이를 true로 변경하여 해결했습니다.

## 질문사항
(집중해 주길 바라는 특정 코드나 로직 없으면 비고)

## 관련 이슈
### 메인 이슈
#11

### 참고 이슈
(- `#[이슈 번호]` 형식으로 연관된 GitHub 이슈 번호를 기입) 
