### PR TITLE
feat: API 응답 및 전역 예외 처리 기반 구축 (#16)

### DIFF
--- a/src/main/java/org/example/gyeonggi_partners/common/dto/ApiResponse.java
+++ b/src/main/java/org/example/gyeonggi_partners/common/dto/ApiResponse.java
@@ -1,0 +1,48 @@
+package org.example.gyeonggi_partners.common.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.example.gyeonggi_partners.common.exception.ErrorCode;
+
+/**
+ * API 응답을 위한 표준 래퍼 클래스 (Record)
+ * @param code    애플리케이션 고유 응답 코드
+ * @param message 응답 메시지
+ * @param data    실제 응답 데이터
+ * @param <T>     응답 데이터의 타입
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL) // data가 null일 경우 JSON에서 제외
+public record ApiResponse<T>(
+        String code,
+        String message,
+        T data
+) {
+
+    /**
+     * 성공 응답을 생성합니다. 데이터와 메시지를 포함합니다.
+     */
+    public static <T> ApiResponse<T> success(T data, String message) {
+        return new ApiResponse<>("SUCCESS", message, data);
+    }
+
+    /**
+     * 성공 응답을 생성합니다. 데이터만 포함합니다.
+     */
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>("SUCCESS", "성공", data);
+    }
+
+    /**
+     * 실패 응답을 생성합니다. ErrorCode를 사용합니다.
+     */
+    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
+        return new ApiResponse<>(errorCode.getCode(), errorCode.getMessage(), null);
+    }
+
+    /**
+     * 실패 응답을 생성합니다. ErrorCode와 추가 메시지를 사용합니다.
+     */
+    public static <T> ApiResponse<T> error(ErrorCode errorCode, String message) {
+        return new ApiResponse<>(errorCode.getCode(), message, null);
+    }
+}

--- a/src/main/java/org/example/gyeonggi_partners/common/dto/ErrorResponse.java
+++ b/src/main/java/org/example/gyeonggi_partners/common/dto/ErrorResponse.java
@@ -1,0 +1,11 @@
+package org.example.gyeonggi_partners.common.dto;
+
+
+import org.example.gyeonggi_partners.common.exception.ErrorCode;
+
+public record ErrorResponse(String message) {
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getMessage());
+    }
+}

--- a/src/main/java/org/example/gyeonggi_partners/common/exception/BusinessException.java
+++ b/src/main/java/org/example/gyeonggi_partners/common/exception/BusinessException.java
@@ -1,0 +1,15 @@
+package org.example.gyeonggi_partners.common.exception;
+
+
+import lombok.Getter;
+
+public class BusinessException extends RuntimeException {
+
+    @Getter
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/org/example/gyeonggi_partners/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/gyeonggi_partners/common/exception/ErrorCode.java
@@ -1,0 +1,7 @@
+package org.example.gyeonggi_partners.common.exception;
+
+public interface ErrorCode {
+    int getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/org/example/gyeonggi_partners/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/gyeonggi_partners/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package org.example.gyeonggi_partners.common.exception;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.gyeonggi_partners.common.dto.ApiResponse;
+import org.example.gyeonggi_partners.common.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * 우리가 직접 정의한 BusinessException을 처리합니다.
+     */
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ApiResponse<?>> handleBusinessException(final BusinessException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        log.error("handleBusinessException : {}", errorCode.getMessage());
+
+        final ApiResponse<?> response = ApiResponse.error(errorCode);
+
+        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+    }
+
+}

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/exception/DiscussionRoomErrorCode.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/exception/DiscussionRoomErrorCode.java
@@ -1,0 +1,37 @@
+package org.example.gyeonggi_partners.domain.discussionRoom.exception;
+
+import org.example.gyeonggi_partners.common.exception.ErrorCode;
+
+public enum DiscussionRoomErrorCode implements ErrorCode {
+
+    ROOM_NOT_FOUND(404, "R001", "존재하지 않는 논의방입니다."),
+    OFFICIALS_ONLY_ROOM(403, "R002", "이 논의방은 공무원만 참여할 수 있습니다."),
+    USERS_ONLY_ROOM(403, "R003", "이 논의방은 일반 사용자만 참여할 수 있습니다."),
+    REGION_MISMATCH(403, "R003", "해당 지역 주민만 참여할 수 있는 논의방입니다."),
+    ALREADY_JOINED_ROOM(409, "R005", "이미 참여 중인 논의방입니다."),
+    NOT_A_ROOM_MEMBER(403, "R006", "해당 논의방의 멤버가 아닙니다.");
+    DiscussionRoomErrorCode (int status, String code, String message){
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/org/example/gyeonggi_partners/domain/message/exception/MessageErrorCode.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/message/exception/MessageErrorCode.java
@@ -1,0 +1,37 @@
+package org.example.gyeonggi_partners.domain.message.exception;
+
+
+import org.example.gyeonggi_partners.common.exception.ErrorCode;
+
+public enum MessageErrorCode implements ErrorCode {
+
+
+    MESSAGE_CONTENT_EMPTY(400, "M001", "메시지 내용을 입력해주세요."),
+    MESSAGE_TOO_LONG(400, "M002", "메시지는 2000자 이하로 입력해주세요."),
+    NOT_A_ROOM_MEMBER(403, "M003", "해당 논의방의 멤버가 아닙니다.");
+
+    MessageErrorCode (int status, String code, String message){
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/org/example/gyeonggi_partners/domain/proposal/exception/ProposalErrorCode.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/proposal/exception/ProposalErrorCode.java
@@ -1,0 +1,43 @@
+package org.example.gyeonggi_partners.domain.proposal.exception;
+
+import org.example.gyeonggi_partners.common.exception.ErrorCode;
+
+public enum ProposalErrorCode implements ErrorCode {
+
+    /**
+     * 더 정의하거나 삭제해야할 상수 있는지 체크해볼것.
+     * */
+
+    // Enum 상수 정의
+    PROPOSAL_NOT_FOUND(404, "P001", "존재하지 않는 제안서입니다."),
+    PROPOSAL_BEING_EDITED(409, "P002", "다른 사용자가 현재 제안서를 수정 중입니다."),
+    ALREADY_CONSENTED(409, "P003", "이미 동의한 제안서입니다."),
+    PROPOSAL_LOCKED(409, "P004", "현재 동의가 진행 중인 제안서는 수정할 수 없습니다."),
+    EDIT_CONFLICT(409, "P005", "다른 사용자에 의해 문서가 수정되었습니다. 페이지를 새로고침 해주세요.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    ProposalErrorCode (int status, String code, String message){
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public int getStatus() {
+        return this.status; // 0 대신 현재 객체의 status 필드를 반환합니다.
+    }
+
+    @Override
+    public String getCode() { // ErrorCode 인터페이스에 getCode()가 있다고 가정
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message; // "" 대신 현재 객체의 message 필드를 반환합니다.
+    }
+
+}

--- a/src/main/java/org/example/gyeonggi_partners/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,43 @@
+package org.example.gyeonggi_partners.domain.user.exception;
+
+
+import org.example.gyeonggi_partners.common.exception.ErrorCode;
+
+public enum UserErrorCode implements ErrorCode {
+
+    // 회원가입 관련
+    DUPLICATE_LOGIN_ID(409, "U001", "이미 사용 중인 아이디입니다."),
+    DUPLICATE_EMAIL(409, "U002", "이미 사용 중인 이메일입니다."),
+    DUPLICATE_PHONE_NUMBER(409, "U003", "이미 등록된 전화번호입니다."),
+
+    // 이메일 인증 관련
+    INVALID_VERIFICATION_CODE(400, "C001", "인증번호가 올바르지 않거나 만료되었습니다."),
+
+    // 로그인 관련
+    LOGIN_FAILED(401, "A001", "아이디 또는 비밀번호가 일치하지 않습니다.");
+
+    UserErrorCode(int status, String code, String message){
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return this.status; // 0 대신 현재 객체의 status 필드를 반환합니다.
+    }
+
+    @Override
+    public String getCode() { // ErrorCode 인터페이스에 getCode()가 있다고 가정
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message; // "" 대신 현재 객체의 message 필드를 반환합니다.
+    }
+}


### PR DESCRIPTION
## PR 요약
API 응답 형식을 표준화하고, 애플리케이션 전역에서 발생하는 예외를 일관되게 처리하기 위한 기반을 마련합니다.

`ApiResponse` DTO와 `GlobalExceptionHandler`를 도입하고, 도메인별 `ErrorCode`를 정의하여 향후 개발의 안정성과 생산성을 높이는 것을 목표로 합니다.

## 변경 내용
### **기능 추가:**
- 전역 예외 처리 시스템 구축: `@RestControllerAdvice`를 사용한 `GlobalExceptionHandler`를 추가하여, `BusinessException`을 중앙에서 일관되게 처리합니다.
- 표준 API 응답 래퍼(`ApiResponse`) 추가: 모든 API 응답을 `code`, `message`, `data` 형식으로 표준화하여 클라이언트와의 통신 규약을 명확히 합니다.
- 도메인별 `ErrorCode` 정의: `User`, `Room`, `Proposal`, `Message` 각 도메인에서 발생할 수 있는 예외 상황을 Enum으로 체계화하여 관리합니다.

### **버그 수정:**
- 해당 없음

### **성능 개선:**
- 해당 없음

### **기타:**
- 해당 없음

## 마주했던 문제 상황

##질문사항 
비고

## 관련이슈

### 메인이슈
- #16 
- 
### 참고이슈 
비고
