### PR TITLE
GHCR 패키지 생성 권한 오류 해결

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -14,13 +14,17 @@ on:
 jobs:
   # 'deploy'라는 이름의 작업을 정의합니다. 이 작업은 하나의 가상 머신에서 실행됩니다.
   deploy:
-    # ❗️ 이 작업의 실행 조건을 명시합니다.
+    # 이 작업의 실행 조건을 명시합니다.
     # Pull Request가 'merged'(병합)된 상태로 닫혔을 경우에만 아래 단계를 실행합니다.
     # (단순히 닫기만 한 PR에서는 배포가 실행되지 않습니다.)
     if: github.event.pull_request.merged == true
 
     # 이 작업이 실행될 가상 환경을 지정합니다. (최신 버전의 우분투 리눅스)
     runs-on: ubuntu-latest
+
+    permissions:
+        contents: read
+        packages: write
 
     # 이 작업에서 순서대로 실행될 단계(Step)들입니다.
     steps:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,6 +10,8 @@ on:
     # Pull Request가 'closed'(닫혔을 때) 상태일 때만 실행합니다.
     types: [ closed ]
 
+  # 2. 수동 실행
+  workflow_dispatch:
 # 워크플로우에 포함될 작업(Job)들의 묶음입니다.
 jobs:
   # 'deploy'라는 이름의 작업을 정의합니다. 이 작업은 하나의 가상 머신에서 실행됩니다.


### PR DESCRIPTION
## PR 요약

GitHub Actions 워크플로우 실행 시 발생하던 GHCR(GitHub Container Registry) 패키지 생성 권한 오류를 해결하여 CI/CD 파이프라인을 안정화했습니다.

---

## 변경 내용

### **기능 추가:**

비고

### **버그 수정:**

* **GHCR 패키지 생성 권한 오류 해결**: 워크플로우가 GHCR에 Docker 이미지를 푸시(push)할 권한이 없어 배포가 실패하는 문제를 수정했습니다.

### **성능 개선:**

비고

### **기타:**

* `deploy-dev.yml` 파일에 `permissions` 블록을 추가하여 `GITHUB_TOKEN`에 패키지 쓰기(`write`) 권한을 명시적으로 부여했습니다.



## 마주했던 문제 상황

**문제 상황**: Docker 이미지 빌드 성공 후, GHCR로 이미지를 푸시하는 단계에서 `denied: installation not allowed to Create organization package` 라는 권한 에러가 발생했습니다.

**해결 방법**: 워크플로우를 실행하는 `GITHUB_TOKEN`에 기본적으로 조직 패키지를 생성할 수 있는 쓰기(`write`) 권한이 부여되지 않는 것이 원인이었습니다. 이를 해결하기 위해 워크플로우 파일(`deploy-dev.yml`)의 작업(job)에 `permissions` 블록을 추가하여 `packages: write` 권한을 명시적으로 부여함으로써 문제를 해결했습니다.



## 질문사항

비고

---

## 관련 이슈

### 메인 이슈

- #32

### 참고 이슈

-   `#[이슈 번호]`