### PR TITLE
feat(fix): 사용자 닉네임 중복 예외 처리 구현

### DIFF
--- a/src/main/java/org/example/gyeonggi_partners/domain/user/application/UserService.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/user/application/UserService.java
@@ -52,6 +52,7 @@ public class UserService {
         validateDuplicateLoginId(req.getLoginId());
         validateDuplicateEmail(req.getEmail());
         validateDuplicatePhoneNumber(req.getPhoneNumber());
+        validateDuplicateUserNickname(req.getNickname());
 
         // 2. 평문 비밀번호 검증 (암호화 전)
         validatePlainPassword(req.getPassword());
@@ -108,6 +109,14 @@ public class UserService {
         }
     }
 
+    /**
+     * 이메일 중복 검증
+     */
+    private void validateDuplicateUserNickname(String nickname) {
+        if (userRepository.existsByUserNickname(nickname)) {
+            throw new BusinessException(UserErrorCode.DUPLICATE_USER_NICKNAME);
+        }
+    }
     /**
      * 평문 비밀번호 검증 (암호화 전)
      */

--- a/src/main/java/org/example/gyeonggi_partners/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/user/domain/repository/UserRepository.java
@@ -39,6 +39,13 @@ public interface UserRepository {
     boolean existsByPhoneNumber(String phoneNumber);
 
     /**
+     * 사용자 닉네임 중복 확인
+     * @param userNickname 전화번호
+     * @return 존재 여부
+     */
+    boolean existsByUserNickname(String userNickname);
+
+    /**
      * 로그인 ID로 사용자를 조회합니다.
      * @param loginId 로그인 ID
      * @return Optional<User> (사용자가 없을 수도 있으므로)

--- a/src/main/java/org/example/gyeonggi_partners/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/user/exception/UserErrorCode.java
@@ -9,7 +9,7 @@ public enum UserErrorCode implements ErrorCode {
     DUPLICATE_LOGIN_ID(409, "U001", "이미 사용 중인 아이디입니다."),
     DUPLICATE_EMAIL(409, "U002", "이미 사용 중인 이메일입니다."),
     DUPLICATE_PHONE_NUMBER(409, "U003", "이미 등록된 전화번호입니다."),
-
+    DUPLICATE_USER_NICKNAME(409, "U004", "이미 등록된 사용자 닉네임입니다."),
     // 이메일 인증 관련
     INVALID_VERIFICATION_CODE(400, "C001", "인증번호가 올바르지 않거나 만료되었습니다."),
 

--- a/src/main/java/org/example/gyeonggi_partners/domain/user/infra/persistence/UserJpaRepository.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/user/infra/persistence/UserJpaRepository.java
@@ -26,6 +26,11 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
     boolean existsByPhoneNumber(String phoneNumber);
 
     /**
+     * 전화번호 존재 여부 확인
+     */
+    boolean existsByNickname(String nickname);
+
+    /**
      * 로그인 ID로 UserEntity 조회
      */
     Optional<UserEntity> findByLoginId(String loginId);

--- a/src/main/java/org/example/gyeonggi_partners/domain/user/infra/persistence/UserRepositoryImpl.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/user/infra/persistence/UserRepositoryImpl.java
@@ -40,6 +40,11 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public boolean existsByUserNickname(String userNickname) {
+        return userJpaRepository.existsByNickname(userNickname);
+    }
+
+    @Override
     public Optional<User> findByLoginId(String loginId) {
         return userJpaRepository.findByLoginId(loginId)
                 .map(UserEntity::toDomain);


### PR DESCRIPTION
## PR 요약
닉네임 중복 검증을 비지니스 로직에서 처리하지 못하고 DB에서 처리했음. 그로 인해 사용자가 이해하기 어려운 에러메시지 형태로 클라이언트에 반환

## 변경 내용
닉네임 중복 커스텀 에러코드를 만든뒤, 이를 도메인 엔티티와 비지니스로직에서 처리하는 로직을 추가함

### **버그 수정:** 
변경 내용이 곧 버그수정

### **성능 개선:** 
(개선된 부분 및 관련 데이터 없으면 비고)

### **기타:** 
(기타 변경 내용 없으면 비고)

## 마주했던 문제 상황
(마주했던 문제 상황 및 해결 방법)

## 질문사항
(집중해 주길 바라는 특정 코드나 로직 없으면 비고)

## 관련 이슈
### 메인 이슈
- #47 

### 참고 이슈
(- `#[이슈 번호]` 형식으로 연관된 GitHub 이슈 번호를 기입)