### PR TITLE
fix(api): 원격 서버 논의방 생성 500 에러 해결 (PostgreSQL ENUM 매핑 완성)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ repositories {
 }
 
 dependencies {
+    implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.7.3")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/discussionRoom/DiscussionRoomEntity.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/discussionRoom/DiscussionRoomEntity.java
@@ -1,5 +1,6 @@
 package org.example.gyeonggi_partners.domain.discussionRoom.infra.persistence.discussionRoom;
 
+
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,7 +10,11 @@ import org.example.gyeonggi_partners.domain.discussionRoom.domain.model.AccessLe
 import org.example.gyeonggi_partners.domain.discussionRoom.domain.model.DiscussionRoom;
 import org.example.gyeonggi_partners.domain.discussionRoom.domain.model.Region;
 import org.example.gyeonggi_partners.domain.discussionRoom.infra.persistence.member.MemberEntity;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Type;
+import org.hibernate.type.SqlTypes;
 
+import java.sql.SQLType;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,12 +39,14 @@ public class DiscussionRoomEntity extends BaseEntity {
     @Column(name = "description")
     private String description;
 
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @Enumerated(EnumType.STRING)
-    @Column(name = "region", nullable = false)
+    @Column(name = "region", nullable = false, columnDefinition = "region_enum") // DB의 ENUM 타입 이름 명시
     private Region region;
 
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @Enumerated(EnumType.STRING)
-    @Column(name = "access_level", nullable = false)
+    @Column(name = "access_level", nullable = false, columnDefinition = "access_level_enum") // DB의 ENUM 타입 이름 명시
     private AccessLevel accessLevel;
 
     @Column(name = "member_count", nullable = false)


### PR DESCRIPTION
- 원격 서버에서 ENUM 컬럼('access_level', 'region')에 문자열 삽입 시도 $\rightarrow$ 타입 불일치 오류(SQLState: 42804)로 500 에러 발생.
- 엔티티 필드 @JdbcTypeCode(SqlTypes.NAMED_ENUM) 등 추가