### PR TITLE
논의방 1차 리팩토링 PR

### DIFF
--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/application/DiscussionRoomService.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/application/DiscussionRoomService.java
@@ -218,24 +218,24 @@ public class DiscussionRoomService {
 
     public void leaveRoom(Long userId, Long roomId) {
         log.info("논의방 나가기 요청 - userId: {}, roomId: {}", userId, roomId);
-        
-        // 1. Redis 퇴장 처리
+
+        // 1. 나가기 전 남은 인원 확인 (현재 사용자 포함)
+        int remainingUsers = memberRepository.countByRoomId(roomId);
+        log.debug("현재 인원 - roomId: {}, count: {}", roomId, remainingUsers);
+
+        // 2. Redis 퇴장 처리
         cacheRepository.removeUserFromRoom(userId, roomId);
         
         // 2. DB 멤버 삭제
         memberRepository.deleteByUserIdAndRoomId(userId, roomId);
-        
-        // 3. 남은 인원 확인
-        int remainingUsers = memberRepository.countByRoomId(roomId);
-        log.debug("남은 인원 - roomId: {}, count: {}", roomId, remainingUsers);
-        
-        // 4. 마지막 사람이면 방 삭제
-        if (remainingUsers == 0) {
-            log.info("마지막 멤버 퇴장 - 방 삭제 처리 - roomId: {}", roomId);
+
+        // 4. 마지막 사람이 나가면 방 삭제 (나가기 전 1명이었던 경우)
+        if (remainingUsers == 1) {
+            log.info("마지막 멤버 퇴장 - 방 삭제 처리 - roomId: {}, lastUserId: {}", roomId, userId);
             discussionRoomRepository.softDelete(roomId);
-            
-            // creatorId는 알 수 없으므로 Redis만 부분 삭제
-            cacheRepository.evictRoomCache(roomId, null);
+
+            // 마지막 사용자가 나가는 것이므로 해당 userId를 creatorId 자리에 전달
+            cacheRepository.evictRoomCache(roomId, userId);
         }
         
         log.info("논의방 나가기 성공 - userId: {}, roomId: {}", userId, roomId);

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/application/DiscussionRoomService.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/application/DiscussionRoomService.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class DiscussionRoomService {
 
     private final DiscussionRoomRepository discussionRoomRepository;
@@ -44,6 +43,7 @@ public class DiscussionRoomService {
      * @param userId 생성자 ID (현재 로그인한 사용자)
      * @return 생성된 논의방 정보 (입장 완료 상태)
      */
+    @Transactional
     public JoinRoomRes createRoom(CreateDiscussionRoomReq request, Long userId) {
         log.info("논의방 생성 요청 - userId: {}, title: {}", userId, request.getTitle());
         
@@ -84,6 +84,7 @@ public class DiscussionRoomService {
         return JoinRoomRes.of(model, memberNicknames);
     }
 
+    @Transactional
     public JoinRoomRes joinRoom(Long userId, Long roomId) {
         log.info("논의방 입장 요청 - userId: {}, roomId: {}", userId, roomId);
 
@@ -225,6 +226,7 @@ public class DiscussionRoomService {
         );
     }
 
+    @Transactional
     public void leaveRoom(Long userId, Long roomId) {
         log.info("논의방 나가기 요청 - userId: {}, roomId: {}", userId, roomId);
 

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/application/DiscussionRoomService.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/application/DiscussionRoomService.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -141,14 +141,21 @@ public class DiscussionRoomService {
             return DiscussionRoomListRes.of(List.of(), page, size, 0);
         }
 
-        // 2. 각 방 상세 정보 조회 (캐시 활용)
+        // 2. 각 방 상세 정보 조회 (N+1 쿼리 방지: 멤버 수 일괄 조회)
         List<DiscussionRoom> rooms = roomPage.getContent();
+        List<Long> roomIds = rooms.stream()
+                .map(DiscussionRoom::getId)
+                .collect(Collectors.toList());
+
+        // 멤버 수 일괄 조회 (N+1 방지)
+        Map<Long, Integer> memberCountMap = memberRepository.countByRoomIds(roomIds);
+
         List<DiscussionRoomInfo> roomSummaries = rooms.stream()
                 .map(room -> {
                     // retrieveCachingRoom: 캐시 미스 시 DB 조회 후 캐싱
                     DiscussionRoomCacheModel cached = cacheRepository.retrieveCachingRoom(room.getId())
                             .orElseGet(() -> {
-                                int currentUsers = memberRepository.countByRoomId(room.getId());
+                                int currentUsers = memberCountMap.getOrDefault(room.getId(), 0);
                                 return DiscussionRoomCacheModel.fromDomainModel(room, currentUsers);
                             });
                     return DiscussionRoomInfo.from(cached);
@@ -190,18 +197,17 @@ public class DiscussionRoomService {
 
         // 2. 각 방 상세 정보 조회 (N+1 쿼리 방지: 일괄 조회)
         List<Long> roomIds = roomIdPage.getContent();
-        List<DiscussionRoomInfo> roomSummaries = roomIds.stream()
-                .map(roomId -> discussionRoomRepository.findById(roomId))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
         List<DiscussionRoom> rooms = discussionRoomRepository.findAllByIdIn(roomIds);
+
+        // 멤버 수 일괄 조회 (N+1 방지)
+        Map<Long, Integer> memberCountMap = memberRepository.countByRoomIds(roomIds);
 
         List<DiscussionRoomInfo> roomSummaries = rooms.stream()
                 .map(room -> {
                     // retrieveCachingRoom: 캐시 미스 시 DB 조회 후 캐싱
                     DiscussionRoomCacheModel cached = cacheRepository.retrieveCachingRoom(room.getId())
                             .orElseGet(() -> {
-                                int currentUsers = memberRepository.countByRoomId(room.getId());
+                                int currentUsers = memberCountMap.getOrDefault(room.getId(), 0);
                                 return DiscussionRoomCacheModel.fromDomainModel(room, currentUsers);
                             });
                     return DiscussionRoomInfo.from(cached);

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/application/DiscussionRoomService.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/application/DiscussionRoomService.java
@@ -188,12 +188,15 @@ public class DiscussionRoomService {
             return DiscussionRoomListRes.of(List.of(), page, size, 0);
         }
 
-        // 2. 각 방 상세 정보 조회 (캐시 활용)
+        // 2. 각 방 상세 정보 조회 (N+1 쿼리 방지: 일괄 조회)
         List<Long> roomIds = roomIdPage.getContent();
         List<DiscussionRoomInfo> roomSummaries = roomIds.stream()
                 .map(roomId -> discussionRoomRepository.findById(roomId))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
+        List<DiscussionRoom> rooms = discussionRoomRepository.findAllByIdIn(roomIds);
+
+        List<DiscussionRoomInfo> roomSummaries = rooms.stream()
                 .map(room -> {
                     // retrieveCachingRoom: 캐시 미스 시 DB 조회 후 캐싱
                     DiscussionRoomCacheModel cached = cacheRepository.retrieveCachingRoom(room.getId())

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/domain/repository/DiscussionRoomRepository.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/domain/repository/DiscussionRoomRepository.java
@@ -40,4 +40,11 @@ public interface DiscussionRoomRepository {
      * @return 페이징된 논의방 목록
      */
     Page<DiscussionRoom> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    /**
+     * ID 목록으로 논의방 일괄 조회 (N+1 쿼리 방지)
+     * @param ids 논의방 ID 목록
+     * @return 논의방 목록
+     */
+    List<DiscussionRoom> findAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/domain/repository/MemberRepository.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/domain/repository/MemberRepository.java
@@ -4,6 +4,9 @@ import org.example.gyeonggi_partners.domain.discussionRoom.domain.model.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * Member 도메인 Repository 인터페이스
  * 도메인 계층에서 정의하고, 인프라 계층에서 구현
@@ -46,4 +49,11 @@ public interface MemberRepository {
      * @return 페이징된 논의방 ID 목록
      */
     Page<Long> findRoomIdsByUserId(Long userId, Pageable pageable);
+
+    /**
+     * 여러 논의방의 멤버 수 일괄 조회 (N+1 쿼리 방지)
+     * @param roomIds 논의방 ID 목록
+     * @return roomId를 키로, 멤버 수를 값으로 하는 Map
+     */
+    Map<Long, Integer> countByRoomIds(List<Long> roomIds);
 }

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/discussionRoom/DiscussionRoomEntity.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/discussionRoom/DiscussionRoomEntity.java
@@ -53,6 +53,10 @@ public class DiscussionRoomEntity extends BaseEntity {
     // DB에 DEFAULT 1이 설정되어 있지만, Entity에도 초기값 1을 명시하는 것이 안전합니다.
     private Integer memberCount = 1;
 
+    @Version
+    @Column(name = "version")
+    private Long version;
+
     @OneToMany(mappedBy = "discussionRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberEntity> members = new ArrayList<>();
 

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/discussionRoom/DiscussionRoomJpaRepository.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/discussionRoom/DiscussionRoomJpaRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -30,4 +31,11 @@ public interface DiscussionRoomJpaRepository extends JpaRepository<DiscussionRoo
      */
     @Query("SELECT d FROM DiscussionRoomEntity d WHERE d.deletedAt IS NULL ORDER BY d.createdAt DESC")
     Page<DiscussionRoomEntity> findAllByDeletedAtIsNullOrderByCreatedAtDesc(Pageable pageable);
+
+    /**
+     * ID 목록으로 논의방 일괄 조회 (N+1 쿼리 방지)
+     * 삭제되지 않은 것만 조회
+     */
+    @Query("SELECT d FROM DiscussionRoomEntity d WHERE d.id IN :ids AND d.deletedAt IS NULL")
+    List<DiscussionRoomEntity> findAllByIdIn(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/discussionRoom/DiscussionRoomRepositoryImpl.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/discussionRoom/DiscussionRoomRepositoryImpl.java
@@ -7,7 +7,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * DiscussionRoomRepository 구현체
@@ -43,5 +45,15 @@ public class DiscussionRoomRepositoryImpl implements DiscussionRoomRepository {
         Page<DiscussionRoomEntity> entityPage = discussionRoomJpaRepository
                 .findAllByDeletedAtIsNullOrderByCreatedAtDesc(pageable);
         return entityPage.map(DiscussionRoomEntity::toDomain);
+    }
+
+    @Override
+    public List<DiscussionRoom> findAllByIdIn(List<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return List.of();
+        }
+        return discussionRoomJpaRepository.findAllByIdIn(ids).stream()
+                .map(DiscussionRoomEntity::toDomain)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/member/MemberJpaRepository.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/member/MemberJpaRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 /**
  * Member JPA Repository
@@ -31,4 +34,20 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
      */
     @Query("SELECT m.roomId FROM MemberEntity m WHERE m.userId = :userId ORDER BY m.createdAt DESC")
     Page<Long> findRoomIdsByUserIdOrderByJoinedAtDesc(Long userId, Pageable pageable);
+
+    /**
+     * 여러 논의방의 멤버 수 일괄 조회 (N+1 쿼리 방지)
+     * @param roomIds 논의방 ID 목록
+     * @return roomId별 멤버 수 (Projection)
+     */
+    @Query("SELECT m.roomId as roomId, COUNT(m) as count FROM MemberEntity m WHERE m.roomId IN :roomIds GROUP BY m.roomId")
+    List<RoomMemberCount> countByRoomIds(@Param("roomIds") List<Long> roomIds);
+
+    /**
+     * Projection 인터페이스: roomId별 멤버 수
+     */
+    interface RoomMemberCount {
+        Long getRoomId();
+        Long getCount();
+    }
 }

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/member/MemberRepositoryImpl.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/member/MemberRepositoryImpl.java
@@ -7,6 +7,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 /**
  * MemberRepository 구현체
  * 도메인 인터페이스를 JPA로 구현
@@ -42,5 +47,20 @@ public class MemberRepositoryImpl implements MemberRepository {
     @Override
     public Page<Long> findRoomIdsByUserId(Long userId, Pageable pageable) {
         return memberJpaRepository.findRoomIdsByUserIdOrderByJoinedAtDesc(userId, pageable);
+    }
+
+    @Override
+    public Map<Long, Integer> countByRoomIds(List<Long> roomIds) {
+        if (roomIds == null || roomIds.isEmpty()) {
+            return new HashMap<>();
+        }
+
+        List<MemberJpaRepository.RoomMemberCount> counts = memberJpaRepository.countByRoomIds(roomIds);
+
+        return counts.stream()
+                .collect(Collectors.toMap(
+                        MemberJpaRepository.RoomMemberCount::getRoomId,
+                        count -> count.getCount().intValue()
+                ));
     }
 }

--- a/src/main/resources/db/migration/V2__add_version_to_discussion_rooms.sql
+++ b/src/main/resources/db/migration/V2__add_version_to_discussion_rooms.sql
@@ -1,0 +1,12 @@
+-- Add version column for optimistic locking
+ALTER TABLE discussion_rooms
+ADD COLUMN version BIGINT DEFAULT 0;
+
+-- Set existing rows to version 0
+UPDATE discussion_rooms
+SET version = 0
+WHERE version IS NULL;
+
+-- Make version NOT NULL after initial data migration
+ALTER TABLE discussion_rooms
+ALTER COLUMN version SET NOT NULL;


### PR DESCRIPTION
## PR 요약
- 여러  Member가 동시에 논의방을 나갈때 memberCount의 정합성 보장
- 논의방 목록 조회할때 해당 방의 멤버수도 같이 조회. 이때 기존 코드의 N+1문제 해결
- 논의방의 마지막 멤버가 나갔을때, 캐시 무효화가 제대로 이루어지지 않았음. 이를 해결
- 클래스 레벨에 있던 @Transactional 을 각 메소드 레벨로 조정.

## 변경 내용
### **기능 추가:** 
(새로운 기능에 대한 설명 없으면 비고)

### **버그 수정:** 
- 논읭방 마지막 멤버 나갔을때 캐시무효화가 제대로 이뤄지지 않았음. 이는 마지막에 논의방을 나간 멤버는 계속 해당 논의방이 자신이 참여중인 논의방 목록 화면에 띄어짐. 이를 해결

### **성능 개선:** 
- N+1 문제 해결을 통해 DB에 보내는 쿼리 수가 N만큼 감소. 이를 통해 DB의 성능 향상

### **기타:** 
(기타 변경 내용 없으면 비고)

## 마주했던 문제 상황
(마주했던 문제 상황 및 해결 방법)

## 질문사항
(집중해 주길 바라는 특정 코드나 로직 없으면 비고)

## 관련 이슈
### 메인 이슈
- #70 

### 참고 이슈
(- `#[이슈 번호]` 형식으로 연관된 GitHub 이슈 번호를 기입) 