### PR TITLE
논의방 도메인 2차 리팩토링

### DIFF
--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/application/DiscussionRoomService.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/application/DiscussionRoomService.java
@@ -230,25 +230,34 @@ public class DiscussionRoomService {
     public void leaveRoom(Long userId, Long roomId) {
         log.info("논의방 나가기 요청 - userId: {}, roomId: {}", userId, roomId);
 
-        // 1. 나가기 전 남은 인원 확인 (현재 사용자 포함)
+        // 1. 비관적 락으로 방 조회 (다른 트랜잭션 대기)
+        DiscussionRoom room = discussionRoomRepository.findByIdWithLock(roomId)
+                .orElseThrow(() -> new BusinessException(DiscussionRoomErrorCode.ROOM_NOT_FOUND));
+        log.debug("방 잠금 획득 - roomId: {}", roomId);
+
+        // 2. 사용자가 실제로 멤버인지 확인
+        if (!memberRepository.existsByUserIdAndRoomId(userId, roomId)) {
+            throw new BusinessException(DiscussionRoomErrorCode.NOT_A_ROOM_MEMBER);
+        }
+
+        // 3. 삭제 전 남은 인원 확인 (현재 사용자 포함)
         int remainingUsers = memberRepository.countByRoomId(roomId);
-        log.debug("현재 인원 - roomId: {}, count: {}", roomId, remainingUsers);
+        log.debug("삭제 전 인원 - roomId: {}, count: {}", roomId, remainingUsers);
 
-        // 2. Redis 퇴장 처리
+        // 4. Redis 퇴장 처리
         cacheRepository.removeUserFromRoom(userId, roomId);
-        
-        // 2. DB 멤버 삭제
-        memberRepository.deleteByUserIdAndRoomId(userId, roomId);
 
-        // 4. 마지막 사람이 나가면 방 삭제 (나가기 전 1명이었던 경우)
+        // 5. DB 멤버 삭제
+        memberRepository.deleteByUserIdAndRoomId(userId, roomId);
+        log.debug("멤버 삭제 완료 - userId: {}, roomId: {}", userId, roomId);
+
+        // 6. 마지막 사람이 나가면 방 삭제 (삭제 전 1명이었던 경우)
         if (remainingUsers == 1) {
             log.info("마지막 멤버 퇴장 - 방 삭제 처리 - roomId: {}, lastUserId: {}", roomId, userId);
             discussionRoomRepository.softDelete(roomId);
-
-            // 마지막 사용자가 나가는 것이므로 해당 userId를 creatorId 자리에 전달
             cacheRepository.evictRoomCache(roomId, userId);
         }
-        
+
         log.info("논의방 나가기 성공 - userId: {}, roomId: {}", userId, roomId);
     }
 

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/domain/repository/DiscussionRoomRepository.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/domain/repository/DiscussionRoomRepository.java
@@ -47,4 +47,12 @@ public interface DiscussionRoomRepository {
      * @return 논의방 목록
      */
     List<DiscussionRoom> findAllByIdIn(List<Long> ids);
+
+    /**
+     * 논의방 ID로 조회 (비관적 락)
+     * 동시성 제어가 필요한 경우 사용 (SELECT FOR UPDATE)
+     * @param id 논의방 ID
+     * @return 조회된 논의방 (잠금 획득)
+     */
+    Optional<DiscussionRoom> findByIdWithLock(Long id);
 }

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/discussionRoom/DiscussionRoomEntity.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/discussionRoom/DiscussionRoomEntity.java
@@ -9,14 +9,8 @@ import org.example.gyeonggi_partners.domain.common.BaseEntity;
 import org.example.gyeonggi_partners.domain.discussionRoom.domain.model.AccessLevel;
 import org.example.gyeonggi_partners.domain.discussionRoom.domain.model.DiscussionRoom;
 import org.example.gyeonggi_partners.domain.discussionRoom.domain.model.Region;
-import org.example.gyeonggi_partners.domain.discussionRoom.infra.persistence.member.MemberEntity;
 import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.Type;
 import org.hibernate.type.SqlTypes;
-
-import java.sql.SQLType;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * DiscussionRoom JPA 엔티티
@@ -56,9 +50,6 @@ public class DiscussionRoomEntity extends BaseEntity {
     @Version
     @Column(name = "version")
     private Long version;
-
-    @OneToMany(mappedBy = "discussionRoom", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<MemberEntity> members = new ArrayList<>();
 
     @Builder
     private DiscussionRoomEntity(Long id, String title, String description,

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/discussionRoom/DiscussionRoomJpaRepository.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/discussionRoom/DiscussionRoomJpaRepository.java
@@ -1,8 +1,10 @@
 package org.example.gyeonggi_partners.domain.discussionRoom.infra.persistence.discussionRoom;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -38,4 +40,13 @@ public interface DiscussionRoomJpaRepository extends JpaRepository<DiscussionRoo
      */
     @Query("SELECT d FROM DiscussionRoomEntity d WHERE d.id IN :ids AND d.deletedAt IS NULL")
     List<DiscussionRoomEntity> findAllByIdIn(@Param("ids") List<Long> ids);
+
+    /**
+     * 논의방 ID로 조회 (비관적 락)
+     * SELECT FOR UPDATE를 사용하여 동시성 제어
+     * 다른 트랜잭션의 읽기/쓰기를 차단하고 배타적 잠금 획득
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT d FROM DiscussionRoomEntity d WHERE d.id = :roomId AND d.deletedAt IS NULL")
+    Optional<DiscussionRoomEntity> findByIdWithLock(@Param("roomId") Long roomId);
 }

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/discussionRoom/DiscussionRoomRepositoryImpl.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/discussionRoom/DiscussionRoomRepositoryImpl.java
@@ -56,4 +56,10 @@ public class DiscussionRoomRepositoryImpl implements DiscussionRoomRepository {
                 .map(DiscussionRoomEntity::toDomain)
                 .collect(Collectors.toList());
     }
+
+    @Override
+    public Optional<DiscussionRoom> findByIdWithLock(Long id) {
+        return discussionRoomJpaRepository.findByIdWithLock(id)
+                .map(DiscussionRoomEntity::toDomain);
+    }
 }

--- a/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/member/MemberEntity.java
+++ b/src/main/java/org/example/gyeonggi_partners/domain/discussionRoom/infra/persistence/member/MemberEntity.java
@@ -6,8 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.gyeonggi_partners.domain.discussionRoom.domain.model.Member;
-import org.example.gyeonggi_partners.domain.discussionRoom.infra.persistence.discussionRoom.DiscussionRoomEntity;
-import org.example.gyeonggi_partners.domain.user.infra.persistence.UserEntity;
 
 import java.time.LocalDateTime;
 
@@ -43,14 +41,6 @@ public class MemberEntity {
         this.roomId = roomId;
         this.createdAt = createdAt;
     }
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false, insertable = false, updatable = false)
-    private UserEntity user;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "room_id", nullable = false, insertable = false, updatable = false)
-    private DiscussionRoomEntity discussionRoom;
 
     /**
      * 도메인 모델을 엔티티로 변환 (Domain -> Entity)


### PR DESCRIPTION
## PR 요약
멤버-논의방 사이의 양방향 연관관계 제거
논의방 나가기 동시성 이슈 해결

## 변경 내용
### **기능 추가:** 
(새로운 기능에 대한 설명 없으면 비고)

### **버그 수정:** 
논의방을 동시에 나갈시 동시성 처리가 되지 않았어서 데이터 정합성이 깨졌었음. 이를 비관적 락을 통하여 해결함.


### **성능 개선:** 
(개선된 부분 및 관련 데이터 없으면 비고)

### **기타:** 
불필요한 양방향 관계를 제거함으로써, 객체경합도를 낮췄다.

## 마주했던 문제 상황
(마주했던 문제 상황 및 해결 방법)

## 질문사항
(집중해 주길 바라는 특정 코드나 로직 없으면 비고)

## 관련 이슈
### 메인 이슈
- #70 

### 참고 이슈
(- `#[이슈 번호]` 형식으로 연관된 GitHub 이슈 번호를 기입) 